### PR TITLE
Revert "Addresses #591, and standardises MathJax config"

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -55,12 +55,7 @@ function loadMathJax() {
   window.MathJax = null;
   $.getScript("https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML", function() {
     MathJax.Hub.Config({
-      tex2jax: {
-            inlineMath: [ ["$","$"],["\\(","\\)"] ],
-            displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-            processEscapes: true
-         }
-       }
+      tex2jax: {inlineMath: [["$","$"],["\\(","\\)"]]}
     });
   });
 };


### PR DESCRIPTION
Reverts crowdAI/crowdai#592

Sorry - failed the Heroku build. Will look into it.
```
   Caused by:
       V8::Error: Unexpected token punc «}», expected punc «,»
       at js_error (<eval>:3623:12181)
       at croak (<eval>:3623:21897)
```