### PR TITLE
Additions to submissions API GET request

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -21,18 +21,12 @@ class Api::SubmissionsController < Api::BaseController
   def index
     begin
       challenge_id = params[:challenge_id]
-      grading_status = params[:grading_status]
       #allow only own organiser to access this challenge's submissions
       permitted_challenge_ids = @organizer.challenges.pluck(:id).map(&:to_s)
       if !permitted_challenge_ids.include?(challenge_id)
         raise OrganizerNotAuthorized
       end
-      # query param 'grading_status' to filter based on grading_status_cd
-      if grading_status.present?
-        @submissions = Submission.where("challenge_id = ? AND grading_status_cd = ?", challenge_id, grading_status)
-      else
-        @submissions = Submission.where(challenge_id: challenge_id)
-      end
+      set_submissions(challenge_id, params[:grading_status], params[:after], params[:challenge_round_id])
       render json: @submissions, each_serializer: Api::SubmissionSerializer, status: :ok
       rescue ActiveRecord::RecordNotFound
         message = "challenge_id #{challenge_id} not found"
@@ -41,9 +35,39 @@ class Api::SubmissionsController < Api::BaseController
         render json: {message: o}, status: :unauthorized
       rescue => e
         message = e
-        render json: {message: e}, status: :internal_server_error
+        render json: {message: "server error"}, status: :internal_server_error
     end
   end
+
+
+  private
+  def set_submissions(challenge_id, grading_status, after, challenge_round_id)
+    if grading_status.blank? && after.blank? && challenge_round_id.blank?
+      @submissions = Submission.where(challenge_id: challenge_id)
+    elsif grading_status.blank? && after.blank? && challenge_round_id.present?
+      @submissions = Submission.where("challenge_id = ? AND challenge_round_id = ?",
+        challenge_id, challenge_round_id)
+    elsif grading_status.blank? && after.present? && challenge_round_id.present?
+      @submissions = Submission.where("challenge_id = ? AND created_at >= ? AND challenge_round_id = ?",
+        challenge_id, after, challenge_round_id)
+    elsif grading_status.blank? && after.present? && challenge_round_id.blank?
+      @submissions = Submission.where("challenge_id = ? AND created_at >= ?",
+        challenge_id, after)
+    elsif grading_status.present? && after.present? && challenge_round_id.present?
+      @submissions = Submission.where("challenge_id = ? AND grading_status_cd = ? AND created_at >= ? AND challenge_round_id = ?",
+        challenge_id, grading_status, after, challenge_round_id)
+    elsif grading_status.present? && after.present? && challenge_round_id.blank?
+      @submissions = Submission.where("challenge_id = ? AND grading_status_cd = ? AND created_at >= ?",
+        challenge_id, grading_status, after)
+    elsif grading_status.present? && after.blank? && challenge_round_id.blank?
+      @submissions = Submission.where("challenge_id = ? AND grading_status_cd = ?",
+        challenge_id, grading_status)
+    elsif grading_status.present? && after.blank? && challenge_round_id.present?
+      @submissions = Submission.where("challenge_id = ? AND grading_status_cd = ? AND challenge_round_id = ?",
+        challenge_id, grading_status, challenge_round_id)
+    end
+  end
+
 
   private
   def set_organizer

--- a/app/serializers/api/submission_serializer.rb
+++ b/app/serializers/api/submission_serializer.rb
@@ -5,6 +5,8 @@ class Api::SubmissionSerializer < ActiveModel::Serializer
   attributes :id,
     :challenge_id,
     :challenge_name,
+    :challenge_round_id,
+    :created_at,
     :participant_id,
     :participant_email,
     :participant_name,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -426,52 +426,6 @@ ActiveRecord::Schema.define(version: 20180423081313) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "old_leaderboard", id: false, force: :cascade do |t|
-    t.integer "id"
-    t.bigint "row_num"
-    t.bigint "previous_row_num"
-    t.integer "submission_id"
-    t.integer "challenge_id"
-    t.integer "challenge_round_id"
-    t.integer "participant_id"
-    t.string "slug"
-    t.integer "organizer_id"
-    t.string "name"
-    t.bigint "entries"
-    t.float "score"
-    t.float "score_secondary"
-    t.string "media_large"
-    t.string "media_thumbnail"
-    t.string "media_content_type"
-    t.text "description"
-    t.text "description_markdown"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "old_ongoing_leaderboards", id: false, force: :cascade do |t|
-    t.integer "id"
-    t.bigint "row_num"
-    t.bigint "previous_row_num"
-    t.integer "submission_id"
-    t.integer "challenge_id"
-    t.integer "challenge_round_id"
-    t.integer "participant_id"
-    t.string "slug"
-    t.integer "organizer_id"
-    t.string "name"
-    t.bigint "entries"
-    t.float "score"
-    t.float "score_secondary"
-    t.string "media_large"
-    t.string "media_thumbnail"
-    t.string "media_content_type"
-    t.text "description"
-    t.text "description_markdown"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "organizer_applications", id: :serial, force: :cascade do |t|
     t.string "contact_name"
     t.string "email"
@@ -744,90 +698,75 @@ ActiveRecord::Schema.define(version: 20180423081313) do
   add_foreign_key "topics", "participants"
   add_foreign_key "votes", "participants"
 
-  create_view "challenge_organizer_participants", materialized: true,  sql_definition: <<-SQL
-      SELECT DISTINCT cop.id,
-      cop.participant_id,
-      cop.clef_task_id,
-      cop.organizer_id,
-      cop.name,
-      cop.challenge
-     FROM ( SELECT c.id,
-              p.id AS participant_id,
-              c.clef_task_id,
-              c.organizer_id,
-              p.name,
-              c.challenge
-             FROM participants p,
-              challenges c,
-              organizers o
-            WHERE ((p.organizer_id = o.id) AND (c.organizer_id = o.id))
-          UNION
-           SELECT c.id,
-              p.id AS participant_id,
-              c.clef_task_id,
-              c.organizer_id,
-              p.name,
-              c.challenge
-             FROM participants p,
-              challenges c
-            WHERE ((c.clef_challenge IS TRUE) AND (c.clef_task_id IN ( SELECT c1.clef_task_id
-                     FROM challenges c1,
-                      organizers o1,
-                      participants p1
-                    WHERE ((c1.clef_challenge IS TRUE) AND (o1.id = c1.organizer_id) AND (o1.id = p1.organizer_id) AND (p1.id = p.id)))))) cop;
+  create_view "participant_sign_ups",  sql_definition: <<-SQL
+      SELECT count(participants.id) AS count,
+      (date_part('month'::text, participants.created_at))::integer AS mnth,
+      (date_part('year'::text, participants.created_at))::integer AS yr
+     FROM participants
+    GROUP BY ((date_part('month'::text, participants.created_at))::integer), ((date_part('year'::text, participants.created_at))::integer)
+    ORDER BY ((date_part('year'::text, participants.created_at))::integer), ((date_part('month'::text, participants.created_at))::integer);
   SQL
 
-  create_view "challenge_registrations",  sql_definition: <<-SQL
-      SELECT row_number() OVER () AS id,
-      x.challenge_id,
-      x.participant_id,
-      x.registration_type,
-      x.clef_task_id
-     FROM ( SELECT s.challenge_id,
-              s.participant_id,
-              'submission'::text AS registration_type,
-              NULL::integer AS clef_task_id
-             FROM submissions s
-          UNION
-           SELECT s.votable_id,
-              s.participant_id,
-              'heart'::text AS registration_type,
-              NULL::integer AS clef_task_id
-             FROM votes s
-            WHERE ((s.votable_type)::text = 'Challenge'::text)
-          UNION
-           SELECT df.challenge_id,
-              dfd.participant_id,
-              'dataset_download'::text AS text,
-              NULL::integer AS clef_task_id
-             FROM dataset_file_downloads dfd,
-              dataset_files df
-            WHERE (dfd.dataset_file_id = df.id)
-          UNION
-           SELECT c_1.id AS challenge_id,
-              p_1.id AS participant_id,
-              'forum'::text AS registration_type,
-              NULL::integer AS clef_task_id
-             FROM challenges c_1,
-              participants p_1,
-              topics t
-            WHERE ((t.challenge_id = c_1.id) AND (t.participant_id = p_1.id))
-          UNION
-           SELECT t.challenge_id,
-              ps.participant_id,
-              'forum'::text AS registration_type,
-              NULL::integer AS clef_task_id
-             FROM comments ps,
-              topics t
-            WHERE (t.id = ps.topic_id)
-          UNION
-           SELECT c.id,
-              pc.participant_id,
-              'clef_task'::text AS registration_type,
-              pc.clef_task_id
-             FROM participant_clef_tasks pc,
-              challenges c
-            WHERE (c.clef_task_id = pc.clef_task_id)) x;
+  create_view "participant_submissions",  sql_definition: <<-SQL
+      SELECT s.id,
+      s.challenge_id,
+      s.participant_id,
+      p.name,
+      s.grading_status_cd,
+      s.post_challenge,
+      s.score,
+      s.score_secondary,
+      count(f.*) AS files,
+      s.created_at
+     FROM participants p,
+      (submissions s
+       LEFT JOIN submission_files f ON ((f.submission_id = s.id)))
+    WHERE (s.participant_id = p.id)
+    GROUP BY s.id, s.challenge_id, s.participant_id, p.name, s.grading_status_cd, s.post_challenge, s.score, s.score_secondary, s.created_at
+    ORDER BY s.created_at DESC;
+  SQL
+
+  create_view "participant_challenge_counts",  sql_definition: <<-SQL
+      SELECT row_number() OVER () AS row_number,
+      y.challenge_id,
+      y.participant_id,
+      y.registration_type
+     FROM ( SELECT DISTINCT x.challenge_id,
+              x.participant_id,
+              x.registration_type
+             FROM ( SELECT s.challenge_id,
+                      s.participant_id,
+                      'submission'::text AS registration_type
+                     FROM submissions s
+                  UNION
+                   SELECT s.votable_id,
+                      s.participant_id,
+                      'heart'::text AS registration_type
+                     FROM votes s
+                    WHERE ((s.votable_type)::text = 'Challenge'::text)
+                  UNION
+                   SELECT df.challenge_id,
+                      dfd.participant_id,
+                      'dataset_download'::text
+                     FROM dataset_file_downloads dfd,
+                      dataset_files df
+                    WHERE (dfd.dataset_file_id = df.id)
+                  UNION
+                   SELECT c_1.id AS challenge_id,
+                      p_1.id AS participant_id,
+                      'forum'::text AS registration_type
+                     FROM challenges c_1,
+                      participants p_1,
+                      topics t
+                    WHERE ((t.challenge_id = c_1.id) AND (t.participant_id = p_1.id))
+                  UNION
+                   SELECT t.challenge_id,
+                      ps.participant_id,
+                      'forum'::text AS registration_type
+                     FROM comments ps,
+                      topics t
+                    WHERE (t.id = ps.topic_id)) x
+            ORDER BY x.challenge_id, x.participant_id) y;
   SQL
 
   create_view "challenge_round_views",  sql_definition: <<-SQL
@@ -884,6 +823,89 @@ ActiveRecord::Schema.define(version: 20180423081313) do
     WHERE ((c.id = cr.challenge_id) AND (c.id = acr.challenge_id) AND (acr.active IS TRUE));
   SQL
 
+  create_view "challenge_registrations",  sql_definition: <<-SQL
+      SELECT row_number() OVER () AS id,
+      x.challenge_id,
+      x.participant_id,
+      x.registration_type,
+      x.clef_task_id
+     FROM ( SELECT s.challenge_id,
+              s.participant_id,
+              'submission'::text AS registration_type,
+              NULL::integer AS clef_task_id
+             FROM submissions s
+          UNION
+           SELECT s.votable_id,
+              s.participant_id,
+              'heart'::text AS registration_type,
+              NULL::integer AS clef_task_id
+             FROM votes s
+            WHERE ((s.votable_type)::text = 'Challenge'::text)
+          UNION
+           SELECT df.challenge_id,
+              dfd.participant_id,
+              'dataset_download'::text,
+              NULL::integer AS clef_task_id
+             FROM dataset_file_downloads dfd,
+              dataset_files df
+            WHERE (dfd.dataset_file_id = df.id)
+          UNION
+           SELECT c_1.id AS challenge_id,
+              p_1.id AS participant_id,
+              'forum'::text AS registration_type,
+              NULL::integer AS clef_task_id
+             FROM challenges c_1,
+              participants p_1,
+              topics t
+            WHERE ((t.challenge_id = c_1.id) AND (t.participant_id = p_1.id))
+          UNION
+           SELECT t.challenge_id,
+              ps.participant_id,
+              'forum'::text AS registration_type,
+              NULL::integer AS clef_task_id
+             FROM comments ps,
+              topics t
+            WHERE (t.id = ps.topic_id)
+          UNION
+           SELECT c.id,
+              pc.participant_id,
+              'clef_task'::text AS registration_type,
+              pc.clef_task_id
+             FROM participant_clef_tasks pc,
+              challenges c
+            WHERE (c.clef_task_id = pc.clef_task_id)) x;
+  SQL
+
+  create_view "participant_challenges",  sql_definition: <<-SQL
+      SELECT DISTINCT p.id,
+      cr.challenge_id,
+      cr.participant_id,
+      c.organizer_id,
+      c.status_cd,
+      c.challenge,
+      c.private_challenge,
+      c.description,
+      c.rules,
+      c.prizes,
+      c.resources,
+      c.tagline,
+      c.image_file,
+      c.submission_count,
+      c.participant_count,
+      c.page_views,
+      p.name,
+      p.email,
+      p.last_sign_in_at,
+      p.bio,
+      p.github,
+      p.linkedin,
+      p.twitter
+     FROM participants p,
+      challenges c,
+      challenge_registrations cr
+    WHERE ((cr.participant_id = p.id) AND (cr.challenge_id = c.id));
+  SQL
+
   create_view "leaderboards",  sql_definition: <<-SQL
       SELECT base_leaderboards.id,
       base_leaderboards.challenge_id,
@@ -938,107 +960,6 @@ ActiveRecord::Schema.define(version: 20180423081313) do
     WHERE ((base_leaderboards.leaderboard_type_cd)::text = 'ongoing'::text);
   SQL
 
-  create_view "participant_challenge_counts",  sql_definition: <<-SQL
-      SELECT row_number() OVER () AS row_number,
-      y.challenge_id,
-      y.participant_id,
-      y.registration_type
-     FROM ( SELECT DISTINCT x.challenge_id,
-              x.participant_id,
-              x.registration_type
-             FROM ( SELECT s.challenge_id,
-                      s.participant_id,
-                      'submission'::text AS registration_type
-                     FROM submissions s
-                  UNION
-                   SELECT s.votable_id,
-                      s.participant_id,
-                      'heart'::text AS registration_type
-                     FROM votes s
-                    WHERE ((s.votable_type)::text = 'Challenge'::text)
-                  UNION
-                   SELECT df.challenge_id,
-                      dfd.participant_id,
-                      'dataset_download'::text AS text
-                     FROM dataset_file_downloads dfd,
-                      dataset_files df
-                    WHERE (dfd.dataset_file_id = df.id)
-                  UNION
-                   SELECT c_1.id AS challenge_id,
-                      p_1.id AS participant_id,
-                      'forum'::text AS registration_type
-                     FROM challenges c_1,
-                      participants p_1,
-                      topics t
-                    WHERE ((t.challenge_id = c_1.id) AND (t.participant_id = p_1.id))
-                  UNION
-                   SELECT t.challenge_id,
-                      ps.participant_id,
-                      'forum'::text AS registration_type
-                     FROM comments ps,
-                      topics t
-                    WHERE (t.id = ps.topic_id)) x
-            ORDER BY x.challenge_id, x.participant_id) y;
-  SQL
-
-  create_view "participant_challenges",  sql_definition: <<-SQL
-      SELECT DISTINCT p.id,
-      cr.challenge_id,
-      cr.participant_id,
-      c.organizer_id,
-      c.status_cd,
-      c.challenge,
-      c.private_challenge,
-      c.description,
-      c.rules,
-      c.prizes,
-      c.resources,
-      c.tagline,
-      c.image_file,
-      c.submission_count,
-      c.participant_count,
-      c.page_views,
-      p.name,
-      p.email,
-      p.last_sign_in_at,
-      p.bio,
-      p.github,
-      p.linkedin,
-      p.twitter
-     FROM participants p,
-      challenges c,
-      challenge_registrations cr
-    WHERE ((cr.participant_id = p.id) AND (cr.challenge_id = c.id));
-  SQL
-
-  create_view "participant_sign_ups",  sql_definition: <<-SQL
-      SELECT count(participants.id) AS count,
-      (date_part('month'::text, participants.created_at))::integer AS mnth,
-      (date_part('year'::text, participants.created_at))::integer AS yr
-     FROM participants
-    GROUP BY ((date_part('month'::text, participants.created_at))::integer), ((date_part('year'::text, participants.created_at))::integer)
-    ORDER BY ((date_part('year'::text, participants.created_at))::integer), ((date_part('month'::text, participants.created_at))::integer);
-  SQL
-
-  create_view "participant_submissions",  sql_definition: <<-SQL
-      SELECT s.id,
-      s.challenge_id,
-      s.participant_id,
-      p.name,
-      s.grading_status_cd,
-      s.post_challenge,
-      s.score,
-      s.score_secondary,
-      count(f.*) AS files,
-      s.created_at
-     FROM participants p,
-      (submissions s
-       LEFT JOIN submission_files f ON ((f.submission_id = s.id)))
-    WHERE (s.participant_id = p.id)
-    GROUP BY s.id, s.challenge_id, s.participant_id, p.name, s.grading_status_cd, s.post_challenge, s.score, s.score_secondary, s.created_at
-    ORDER BY s.created_at DESC;
-  SQL
-
   create_view "previous_leaderboards",  sql_definition: <<-SQL
       SELECT base_leaderboards.id,
       base_leaderboards.challenge_id,
@@ -1091,6 +1012,39 @@ ActiveRecord::Schema.define(version: 20180423081313) do
       base_leaderboards.post_challenge
      FROM base_leaderboards
     WHERE ((base_leaderboards.leaderboard_type_cd)::text = 'previous_ongoing'::text);
+  SQL
+
+  create_view "challenge_organizer_participants", materialized: true,  sql_definition: <<-SQL
+      SELECT DISTINCT cop.id,
+      cop.participant_id,
+      cop.clef_task_id,
+      cop.organizer_id,
+      cop.name,
+      cop.challenge
+     FROM ( SELECT c.id,
+              p.id AS participant_id,
+              c.clef_task_id,
+              c.organizer_id,
+              p.name,
+              c.challenge
+             FROM participants p,
+              challenges c,
+              organizers o
+            WHERE ((p.organizer_id = o.id) AND (c.organizer_id = o.id))
+          UNION
+           SELECT c.id,
+              p.id AS participant_id,
+              c.clef_task_id,
+              c.organizer_id,
+              p.name,
+              c.challenge
+             FROM participants p,
+              challenges c
+            WHERE ((c.clef_challenge IS TRUE) AND (c.clef_task_id IN ( SELECT c1.clef_task_id
+                     FROM challenges c1,
+                      organizers o1,
+                      participants p1
+                    WHERE ((c1.clef_challenge IS TRUE) AND (o1.id = c1.organizer_id) AND (o1.id = p1.organizer_id) AND (p1.id = p.id)))))) cop;
   SQL
 
 end


### PR DESCRIPTION
Fixes #718 

Changes in this pull request:

- Add additional fields for submissions API GET request
- Add filtering of results for submissions API:
  - by after param (shows submission after and equal to
    created_at datetime)
  - by challenge_round_id (shows submissions associated
   with a specific challenge round id)

@seanfcarroll

