### PR TITLE
Meta params : Refactors handing of meta_params

### DIFF
--- a/app/controllers/api/external_graders_controller.rb
+++ b/app/controllers/api/external_graders_controller.rb
@@ -103,10 +103,19 @@ class Api::ExternalGradersController < Api::BaseController
         if submission.meta.nil?
           meta = params[:meta]
         else
-          # Standardise submission.meta to a Hash, irrespective of the
-          # version of the API
-          submission_meta = clean_meta(submission.meta)
-          meta = submission_meta.deep_merge(params[:meta])
+          if params[:meta_overwrite].present? && pararms[:meta_overwrite]
+            # When the provided parameters have a `meta_overwrite=True`
+            # parrameter, then a merge between the provided meta param
+            # and the submission meta param will *NOT* happen. In this
+            # case, the provided meta_param will overwrite the submission's
+            # meta param.
+            meta = params[:meta]
+          else
+            # Standardise submission.meta to a Hash, irrespective of the
+            # version of the API
+            submission_meta = clean_meta(submission.meta)
+            meta = submission_meta.deep_merge(params[:meta])
+          end
         end
         submission.update({meta: meta})
       end

--- a/app/controllers/api/external_graders_controller.rb
+++ b/app/controllers/api/external_graders_controller.rb
@@ -149,6 +149,9 @@ class Api::ExternalGradersController < Api::BaseController
         # because of this bug :
         # https://github.com/crowdAI/crowdai/issues/737
         # So we return an empty Hash
+        Rails.logger.warn "Found invalid meta key: #{params_meta}.
+        Assuming the user meant an empty Hash, or it is corrupt data.
+        Reference : https://github.com/crowdAI/crowdai/issues/737 "
         return {}
       end
     end

--- a/spec/requests/api/external_graders_controller/external_graders_controller_PATCH_spec.rb
+++ b/spec/requests/api/external_graders_controller/external_graders_controller_PATCH_spec.rb
@@ -273,21 +273,6 @@ RSpec.describe Api::ExternalGradersController, type: :request do
         :new_key=>"hello", :file_key=>"submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"}) }
     end
 
-    context "with valid_meta_attributes - overwrite using meta_overwrite" do
-      before do
-        patch "/api/external_graders/#{submission1.id}",
-          params: valid_meta_attributes,
-          headers: { 'Authorization': auth_header(organizer.api_key) }
-        submission1.reload
-      end
-      it { expect(response).to have_http_status(202) }
-      it { expect(json(response.body)[:message]).to eq("Submission #{submission1.id} updated") }
-      it { expect(json(response.body)[:submission_id]).to eq(submission1.id.to_s)}
-      it { expect(submission1.meta.symbolize_keys).to eq({
-        :impwt_std=>"0.020956583416961033", :ips_std=>"2.0898337641716487",
-        :new_key=>"hello", :file_key=>"submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"}) }
-    end
-
     context "valid_attributes_grading_submitted_with_message" do
       before do
         patch "/api/external_graders/#{submission1.id}",

--- a/spec/requests/api/external_graders_controller/external_graders_controller_PATCH_spec.rb
+++ b/spec/requests/api/external_graders_controller/external_graders_controller_PATCH_spec.rb
@@ -273,6 +273,21 @@ RSpec.describe Api::ExternalGradersController, type: :request do
         :new_key=>"hello", :file_key=>"submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"}) }
     end
 
+    context "with valid_meta_attributes - overwrite using meta_overwrite" do
+      before do
+        patch "/api/external_graders/#{submission1.id}",
+          params: valid_meta_attributes,
+          headers: { 'Authorization': auth_header(organizer.api_key) }
+        submission1.reload
+      end
+      it { expect(response).to have_http_status(202) }
+      it { expect(json(response.body)[:message]).to eq("Submission #{submission1.id} updated") }
+      it { expect(json(response.body)[:submission_id]).to eq(submission1.id.to_s)}
+      it { expect(submission1.meta.symbolize_keys).to eq({
+        :impwt_std=>"0.020956583416961033", :ips_std=>"2.0898337641716487",
+        :new_key=>"hello", :file_key=>"submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"}) }
+    end
+
     context "valid_attributes_grading_submitted_with_message" do
       before do
         patch "/api/external_graders/#{submission1.id}",

--- a/spec/requests/api/external_graders_controller/external_graders_controller_PATCH_spec.rb
+++ b/spec/requests/api/external_graders_controller/external_graders_controller_PATCH_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe Api::ExternalGradersController, type: :request do
       }
     end
 
+    def valid_meta_attributes_update_as_json
+      {
+        meta: JSON.dump({
+          impwt_std: "0.01",
+          ips_std: "3.5",
+          snips: "45.69345202998776",
+          file_key: "submissions/eeeeee-a525-4e5e-97a8-8ff7199be43c"
+        })
+      }
+    end
+
+
     def valid_meta_attributes_partial_update
       {
         meta: {
@@ -63,6 +75,18 @@ RSpec.describe Api::ExternalGradersController, type: :request do
         }
       }
     end
+
+    def valid_meta_attributes_partial_update_as_json
+      {
+        meta: JSON.dump({
+          impwt_std: "0.01",
+          ips_std: "3.5",
+          snips: "45.69345202998776",
+          file_key: "submissions/eeeeee-a525-4e5e-97a8-8ff7199be43c"
+        })
+      }
+    end
+
 
     def valid_meta_attributes_add
       {
@@ -75,6 +99,24 @@ RSpec.describe Api::ExternalGradersController, type: :request do
       }
     end
 
+    def valid_meta_attributes_add_as_json
+      {
+        meta: JSON.dump({
+          impwt_std: "0.020956583416961033",
+          ips_std: "2.0898337641716487",
+          new_key: "hello",
+          file_key: "submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"
+        })
+      }
+    end
+
+    def invalid_meta_attributes
+      {
+        meta: "THIS_IS_AN_INVALID_META_ATTRIBUTE"
+      }
+    end
+
+
     def valid_meta_attributes_multi
       {
         meta: {
@@ -83,6 +125,18 @@ RSpec.describe Api::ExternalGradersController, type: :request do
           snips: "45.69345202998776",
           file_key: "submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"
         }
+      }
+    end
+
+
+    def valid_meta_attributes_multi_as_json
+      {
+        meta: JSON.dump({
+          impwt_std: "0.020956583416961033",
+          ips_std: "2.0898337641716487",
+          snips: "45.69345202998776",
+          file_key: "submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"
+        })
       }
     end
 
@@ -117,10 +171,36 @@ RSpec.describe Api::ExternalGradersController, type: :request do
       it { expect(submission1.media_content_type).to eq(valid_media_attributes[:media_content_type]) }
     end
 
+    context "with invalid_meta_attributes - update" do
+      before do
+        patch "/api/external_graders/#{submission1.id}",
+          params: invalid_meta_attributes,
+          headers: { 'Authorization': auth_header(organizer.api_key) }
+        submission1.reload
+      end
+      it { expect(response).to have_http_status(202) }
+      it { expect(json(response.body)[:message]).to eq("Submission #{submission1.id} updated") }
+      it { expect(json(response.body)[:submission_id]).to eq(submission1.id.to_s)}
+      it { expect(submission1.meta.symbolize_keys).to eq({}) }
+    end
+
     context "with valid_meta_attributes - update" do
       before do
         patch "/api/external_graders/#{submission1.id}",
           params: valid_meta_attributes_update,
+          headers: { 'Authorization': auth_header(organizer.api_key) }
+        submission1.reload
+      end
+      it { expect(response).to have_http_status(202) }
+      it { expect(json(response.body)[:message]).to eq("Submission #{submission1.id} updated") }
+      it { expect(json(response.body)[:submission_id]).to eq(submission1.id.to_s)}
+      it { expect(submission1.meta.symbolize_keys).to eq(valid_meta_attributes_update[:meta]) }
+    end
+
+    context "with valid_meta_attributes (as JSON)- update" do
+      before do
+        patch "/api/external_graders/#{submission1.id}",
+          params: valid_meta_attributes_update_as_json,
           headers: { 'Authorization': auth_header(organizer.api_key) }
         submission1.reload
       end
@@ -146,10 +226,42 @@ RSpec.describe Api::ExternalGradersController, type: :request do
         :snips=>"45.69345202998776", :file_key=>"submissions/eeeeee-a525-4e5e-97a8-8ff7199be43c"}) }
     end
 
+    context "with valid_meta_attributes (as JSON)- partial update" do
+      before do
+        patch "/api/external_graders/#{submission1.id}",
+          params: valid_meta_attributes_partial_update_as_json,
+          headers: { 'Authorization': auth_header(organizer.api_key) }
+        submission1.reload
+      end
+      it { expect(response).to have_http_status(202) }
+      it { expect(json(response.body)[:message]).to eq("Submission #{submission1.id} updated") }
+      it { expect(json(response.body)[:submission_id]).to eq(submission1.id.to_s)}
+      it { expect(submission1.meta.symbolize_keys).to eq({
+        :impwt_std=>"0.01",
+        :ips_std=>"3.5",
+        :snips=>"45.69345202998776", :file_key=>"submissions/eeeeee-a525-4e5e-97a8-8ff7199be43c"}) }
+    end
+
+
     context "with valid_meta_attributes - add" do
       before do
         patch "/api/external_graders/#{submission1.id}",
           params: valid_meta_attributes_add,
+          headers: { 'Authorization': auth_header(organizer.api_key) }
+        submission1.reload
+      end
+      it { expect(response).to have_http_status(202) }
+      it { expect(json(response.body)[:message]).to eq("Submission #{submission1.id} updated") }
+      it { expect(json(response.body)[:submission_id]).to eq(submission1.id.to_s)}
+      it { expect(submission1.meta.symbolize_keys).to eq({
+        :impwt_std=>"0.020956583416961033", :ips_std=>"2.0898337641716487",
+        :new_key=>"hello", :file_key=>"submissions/07b2ccb7-a525-4e5e-97a8-8ff7199be43c"}) }
+    end
+
+    context "with valid_meta_attributes (as JSON) - add" do
+      before do
+        patch "/api/external_graders/#{submission1.id}",
+          params: valid_meta_attributes_add_as_json,
           headers: { 'Authorization': auth_header(organizer.api_key) }
         submission1.reload
       end


### PR DESCRIPTION
These changes make the API backward compatibility to all the different kinds of formats (just for reprresenting `meta` we used the data for the challenges in.
Some of the previous disccussion around this problem can be found at 
* https://github.com/crowdAI/crowdai/issues/737