### PR TITLE
 Message for hidden leaderboards

### DIFF
--- a/app/assets/stylesheets/_subnav_tabs.scss
+++ b/app/assets/stylesheets/_subnav_tabs.scss
@@ -23,3 +23,13 @@
 .md-tab-content.active {
   display: block;
 }
+
+.leaderboard-msg {
+  margin: 32px 0 32px 0;
+}
+
+.leaderboard-important-msg {
+  margin-top: 32px;
+  font-style: italic;
+  color: red;
+}

--- a/app/views/challenges/show/_subnav.html.erb
+++ b/app/views/challenges/show/_subnav.html.erb
@@ -6,13 +6,11 @@
               challenge_path(challenge),
               class: tab_class('overview') %>
       </li>
-      <% if policy(challenge).show_leaderboard? %>
-        <li class=<%= tab_class('leaderboard') %> >
+      <li class=<%= tab_class('leaderboard') %> >
           <%= link_to 'Leaderboard',
                 challenge_leaderboards_path(challenge),
                 class: tab_class('leaderboard') %>
-        </li>
-      <% end %>
+      </li>
       <li class=<%= tab_class('discussion') %> >
         <%= link_to 'Discussion',
               challenge_topics_path(challenge),

--- a/app/views/leaderboards/index.html.erb
+++ b/app/views/leaderboards/index.html.erb
@@ -10,16 +10,27 @@
                 current_participant: current_participant) %>
 
   <div class="row">
-    <table class="leaderboard">
-      <%= concept(Leaderboard::Cell::TableHead,
-                    @leaderboards,
-                    challenge: @challenge,
-                    current_round: @current_round,
-                    current_participant: current_participant) %>
-      <tbody>
-        <%= render partial: 'leaderboards' %>
-      </tbody>
-    </table>
+    <% if policy(@challenge).show_leaderboard? %>
+      <% unless @challenge.show_leaderboard? %>
+        <div class="leaderboard-important-msg">
+          <p>Leaderboard is only visible to organizers</p>
+        </div>
+      <% end %>
+      <table class="leaderboard">
+          <%= concept(Leaderboard::Cell::TableHead,
+                        @leaderboards,
+                        challenge: @challenge,
+                        current_round: @current_round,
+                        current_participant: current_participant) %>
+          <tbody>
+            <%= render partial: 'leaderboards' %>
+          </tbody>
+      </table>
+    <% else %>
+      <div class="leaderboard-msg">
+        <p>Leaderboard is not displayed yet.</p>
+      </div>
+    <% end %>
   </div>
 
   <% if @post_challenge == 'off' %>


### PR DESCRIPTION
For issue :  Message for hidden leaderboards #783 

When 'Show leaderboard?' is not selected, this is the leaderboard view as an organizer (or admin) :
![screenshot-2018-5-23 crowdai](https://user-images.githubusercontent.com/21169263/40428666-12739ef6-5ea1-11e8-9f14-6c46958b3637.png)

And the leaderboard view as a participant :
![screenshot-2018-5-23 crowdai 1](https://user-images.githubusercontent.com/21169263/40428686-1ffaa506-5ea1-11e8-80f4-c2252b4d7fe4.png)

