### PR TITLE
simple fix for baseline leaderboard precision in view layer, does not alter DB

### DIFF
--- a/app/concepts/leaderboard/cells/table_row.rb
+++ b/app/concepts/leaderboard/cells/table_row.rb
@@ -12,6 +12,10 @@ class Leaderboard::Cell::TableRow < Leaderboard::Cell
     model
   end
 
+  def formatted_score
+    sprintf("%.#{challenge_round.score_precision}f", entry.score)
+  end
+
   def challenge
     @challenge ||= model.challenge
   end

--- a/app/concepts/leaderboard/views/baseline_row.erb
+++ b/app/concepts/leaderboard/views/baseline_row.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <td class="score">
-    <strong><%= entry.score %></strong>
+    <strong><%= formatted_score %></strong>
   </td>
 
   <% if cols.include?(:score_secondary) %>

--- a/app/concepts/leaderboard/views/table_row.erb
+++ b/app/concepts/leaderboard/views/table_row.erb
@@ -39,7 +39,7 @@
   <% end %>
 
   <td class="score">
-    <strong><%= entry.score %></strong>
+    <strong><%= formatted_score %></strong>
   </td>
 
   <% if cols.include?(:score_secondary) %>


### PR DESCRIPTION
The root of the problem is in how the baseline rows are inserted into the Leaderboard.  In `calculate_leaderboard_service.rb#create_leaderboard`, score and secondary_score are set to `submission.score_display` and `submission.secondary_score_display` respectively.  However for a baseline those same values are set to `submission.score` and `submission.secondary_score`.  The `score_display` values are calculated in `truncate_scores`, which operates over all submissions with the appropriate `challenge_round_id`, so it should be safe to use those values with the baseline submissions, but it is unclear to me if that is desired behavior.

In this PR it only fixes the display of the baseline score to account for the precision in the challenge round.  It does add one minor tweak so that all scores will show N digits of precision instead of the current behavior where for example `1.5` shows as `1.5` instead of `1.500` for `N=3`.
![leaderboard](https://user-images.githubusercontent.com/1289794/49305384-6aae1000-f4cf-11e8-9294-253d65868f6b.jpg)
