### PR TITLE
submission score visibility bugfix

### DIFF
--- a/app/views/submissions/_submission.html.erb
+++ b/app/views/submissions/_submission.html.erb
@@ -21,21 +21,24 @@
               <%= status_badge(submission.grading_status_cd) %>
       <% end %>
     </td>
-    <td>
-      <% if submission.score_display.present? %>
-        <%= submission.score_display %>
-      <% else %>
-        –
-      <% end %>
-    </td>
-    <% unless @challenge.secondary_sort_order_cd == 'not_used' %>
+    <% if @challenge.show_leaderboard? || submission.participant.organizer_id == submission.challenge.organizer_id || 
+          submission.participant.admin? %>
       <td>
-        <% if submission.score_secondary_display.present? %>
-          <%= submission.score_secondary_display %>
+        <% if submission.score_display.present? %>
+          <%= submission.score_display %>
         <% else %>
           –
         <% end %>
       </td>
+      <% unless @challenge.secondary_sort_order_cd == 'not_used' %>
+        <td>
+          <% if submission.score_secondary_display.present? %>
+            <%= submission.score_secondary_display %>
+          <% else %>
+            –
+          <% end %>
+        </td>
+      <% end %>
     <% end %>
     <td class='description'>
       <%= submission.grading_message %>


### PR DESCRIPTION
- Since most organizers do not wish to show the leaderboard until the challenge ends, the scores should actually also not be visible in the submissions tab. It does not seem to make sense to hide the leaderboard but still show their scores to the participant. This condition to only show the scores in the submission tab if the leaderboard is active was actually already implemented last year, however it seems to have been removed.
- Could someone please check if the code makes sense because I'm not familiar anymore with ruby/RoR
- I could not test it locally because i don't have the crowdai dev environment set up